### PR TITLE
CCHS-357 moving mapdata to imports instead of depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,9 +14,9 @@ Copyright: This software is in the public domain because it contains materials
     official USGS copyright policy at
     https://www.usgs.gov/visual-id/credit_usgs.html#copyright
 Depends:
-    R (>= 3.1.0),
-    mapdata
+    R (>= 3.1.0)
 Imports:
+    mapdata,
     XML,
     png,
     scales,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,14 +14,14 @@ Copyright: This software is in the public domain because it contains materials
     official USGS copyright policy at
     https://www.usgs.gov/visual-id/credit_usgs.html#copyright
 Depends:
-    R (>= 3.1.0)
+    R (>= 3.1.0),
+    mapdata
 Imports:
     XML,
     png,
     scales,
     jsonlite,
     maps,
-    mapdata,
     httr,
     base64enc,
     yaml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,12 +16,12 @@ Copyright: This software is in the public domain because it contains materials
 Depends:
     R (>= 3.1.0)
 Imports:
-    mapdata,
     XML,
     png,
     scales,
     jsonlite,
     maps,
+    mapdata,
     httr,
     base64enc,
     yaml

--- a/inst/extdata/installPackages.R
+++ b/inst/extdata/installPackages.R
@@ -38,6 +38,12 @@ hazardItemsImports <- function (lib.loc = NULL, encoding = "") {
   }
 
   imports <- strsplit(unlist(desc$Imports), "[\n,]+")
+  #get depends too
+  depends <- strsplit(unlist(desc$Depends), "[\n,]+")
+  #remove the R version specification
+  depends <- list(depends[[1]][3])
+  #merge them all back together
+  imports <- Map(c, imports, depends)
   return(imports[[1]][-1]) # hack to remove "" from results of strsplit() above
 }
 


### PR DESCRIPTION
hazardItems install fails without it so logically should be in imports