### PR TITLE
success/Success httr version issues; making it work for either way..

### DIFF
--- a/R/addLayer.R
+++ b/R/addLayer.R
@@ -26,7 +26,6 @@ addLayer = function(filename, ...) {
   response <- POST(url=layerUrl, body=rawData, 
                    content_type('application/octet-stream'),
                    add_headers('Authorization' = getAuth(), 'Connection'='keep-alive'))
-  print(response)
   if (http_status(response)$category == "success" | http_status(response)$category == "Success") {
     location <- headers(response)$Location
     bits <- strsplit(location,"/")

--- a/R/addLayer.R
+++ b/R/addLayer.R
@@ -26,8 +26,8 @@ addLayer = function(filename, ...) {
   response <- POST(url=layerUrl, body=rawData, 
                    content_type('application/octet-stream'),
                    add_headers('Authorization' = getAuth(), 'Connection'='keep-alive'))
-  
-  if (http_status(response)$category == "Success") {
+  print(response)
+  if (http_status(response)$category == "success" | http_status(response)$category == "Success") {
     location <- headers(response)$Location
     bits <- strsplit(location,"/")
     id <- tail(bits[[1]],n=1)

--- a/R/addLayer.R
+++ b/R/addLayer.R
@@ -26,7 +26,7 @@ addLayer = function(filename, ...) {
   response <- POST(url=layerUrl, body=rawData, 
                    content_type('application/octet-stream'),
                    add_headers('Authorization' = getAuth(), 'Connection'='keep-alive'))
-  if (http_status(response)$category == "success" | http_status(response)$category == "Success") {
+  if (tolower(http_status(response)$category) == "success") {
     location <- headers(response)$Location
     bits <- strsplit(location,"/")
     id <- tail(bits[[1]],n=1)

--- a/R/checkItemExists.R
+++ b/R/checkItemExists.R
@@ -15,7 +15,7 @@ checkItemExists <- function(itemID) {
   
   response <- GET(url = paste0(pkg.env$item_json, itemID))
   
-  return(http_status(response)$category == "Success")
+  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
   
   
 }

--- a/R/checkItemExists.R
+++ b/R/checkItemExists.R
@@ -15,7 +15,7 @@ checkItemExists <- function(itemID) {
   
   response <- GET(url = paste0(pkg.env$item_json, itemID))
   
-  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
+  return(tolower(http_status(response)$category) == "success")
   
   
 }

--- a/R/deleteDownload.R
+++ b/R/deleteDownload.R
@@ -18,5 +18,5 @@ deleteDownload = function(itemId, ...) {
   response <- DELETE(url=downloadUrl,
                    add_headers('Authorization' = getAuth(),
                                'Connection'='keep-alive'))
-  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
+  return(tolower(http_status(response)$category) == "success")
 }

--- a/R/deleteDownload.R
+++ b/R/deleteDownload.R
@@ -18,5 +18,5 @@ deleteDownload = function(itemId, ...) {
   response <- DELETE(url=downloadUrl,
                    add_headers('Authorization' = getAuth(),
                                'Connection'='keep-alive'))
-  return(http_status(response)$category == "Success")
+  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
 }

--- a/R/deleteTileCache.R
+++ b/R/deleteTileCache.R
@@ -17,5 +17,5 @@ deleteTileCache = function(...) {
   response <- DELETE(url=tileCacheUrl,
                      add_headers('Authorization' = getAuth(),
                                  'Connection'='keep-alive'), verbose())
-  return(http_status(response)$category == "Success")
+  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
 }

--- a/R/deleteTileCache.R
+++ b/R/deleteTileCache.R
@@ -17,5 +17,5 @@ deleteTileCache = function(...) {
   response <- DELETE(url=tileCacheUrl,
                      add_headers('Authorization' = getAuth(),
                                  'Connection'='keep-alive'), verbose())
-  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
+  return(tolower(http_status(response)$category) == "success")
 }

--- a/R/downloadItem.R
+++ b/R/downloadItem.R
@@ -13,5 +13,5 @@
 downloadItem = function(itemId, ...) {
   downloadUrl <- paste0(pkg.env$item_download, itemId)
   response <- GET(url=downloadUrl)
-  return(http_status(response)$category == "Success")
+  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
 }

--- a/R/downloadItem.R
+++ b/R/downloadItem.R
@@ -13,5 +13,5 @@
 downloadItem = function(itemId, ...) {
   downloadUrl <- paste0(pkg.env$item_download, itemId)
   response <- GET(url=downloadUrl)
-  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
+  return(tolower(http_status(response)$category) == "success")
 }

--- a/R/refreshItemThumbnail.R
+++ b/R/refreshItemThumbnail.R
@@ -31,6 +31,6 @@ refreshItemThumbnail <- function(itemID, ...) {
                    content_type('text/plain'),
                    add_headers('Authorization' = getAuth(), 'Connection'='keep-alive'))
   
-  return(http_status(response)$category == "Success")
+  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
   
 }

--- a/R/refreshItemThumbnail.R
+++ b/R/refreshItemThumbnail.R
@@ -31,6 +31,6 @@ refreshItemThumbnail <- function(itemID, ...) {
                    content_type('text/plain'),
                    add_headers('Authorization' = getAuth(), 'Connection'='keep-alive'))
   
-  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
+  return(tolower(http_status(response)$category) == "success")
   
 }

--- a/R/template.R
+++ b/R/template.R
@@ -43,5 +43,5 @@ template = function(templateId, items, ...) {
   response <- POST(url=url, body=json,
                    content_type('application/json'),
                    add_headers('Authorization' = getAuth(), 'Connection'='keep-alive'))
-  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
+  return(tolower(http_status(response)$category) == "success")
 }

--- a/R/template.R
+++ b/R/template.R
@@ -43,5 +43,5 @@ template = function(templateId, items, ...) {
   response <- POST(url=url, body=json,
                    content_type('application/json'),
                    add_headers('Authorization' = getAuth(), 'Connection'='keep-alive'))
-  return(http_status(response)$category == "Success")
+  return(http_status(response)$category == "success" | http_status(response)$category == "Success")
 }


### PR DESCRIPTION
this seems to work fine, not sure if it's a bad fix. but, i had version httr 1 local, and 1.2.1 on the server, and it worked together ok. also see debugging this logic seems to work:

```
Browse[3]> http_status(response)$category == "Success"
[1] TRUE
Browse[3]> http_status(response)$category == "success"
[1] FALSE
Browse[3]> http_status(response)$category == "success" | http_status(response)$category == "Success"
[1] TRUE
```